### PR TITLE
Feed updates

### DIFF
--- a/lib/feed_me/content.ex
+++ b/lib/feed_me/content.ex
@@ -221,4 +221,20 @@ defmodule FeedMe.Content do
       description: description
     }
   end
+
+  def get_feed_items_from_rss_url(url) do
+    %Response{body: body} = HTTPoison.get!(url)
+
+    %{
+      "rss" => %{
+        "#content" => %{
+          "channel" => %{
+            "item" => items
+          }
+        }
+      }
+    } = XmlToMap.naive_map(body)
+
+    items
+  end
 end

--- a/lib/feed_me/content/feed.ex
+++ b/lib/feed_me/content/feed.ex
@@ -6,6 +6,8 @@ defmodule FeedMe.Content.Feed do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @derive {Jason.Encoder, only: [:id, :name, :description, :url, :items]}
+
   schema "feeds" do
     field :description, :string
     field :name, :string

--- a/lib/feed_me_web/controllers/feed_controller.ex
+++ b/lib/feed_me_web/controllers/feed_controller.ex
@@ -1,0 +1,20 @@
+defmodule FeedMeWeb.FeedController do
+  use FeedMeWeb, :controller
+
+  alias FeedMe.Content
+  alias Plug.Conn
+
+  # This plug will execute before every handler in this list
+  plug FeedMeWeb.Plugs.VerifyHeader, realm: "Bearer"
+
+  def index(conn, _params) do
+    feeds =
+      Content.list_feeds()
+      |> Enum.map(fn feed ->
+        items = Content.get_feed_items_from_rss_url(feed.url)
+        Map.put(feed, :items, items)
+      end)
+
+    Conn.send_resp(conn, :ok, Jason.encode!(feeds))
+  end
+end

--- a/lib/feed_me_web/controllers/plugs/verify_header.ex
+++ b/lib/feed_me_web/controllers/plugs/verify_header.ex
@@ -9,29 +9,29 @@ defmodule FeedMeWeb.Plugs.VerifyHeader do
   end
 
   def call(conn, _params) do
-    %{"authorization" => authorization} = Enum.into(conn.req_headers, %{})
+    case Enum.into(conn.req_headers, %{}) do
+      %{"authorization" => authorization} ->
+        [_bearer, token] = String.split(authorization, " ")
+        user = FeedMe.Account.get_user_by_token(token)
 
-    if authorization do
-      [_bearer, token] = String.split(authorization, " ")
-      user = FeedMe.Account.get_user_by_token(token)
+        if user != nil do
+          conn
+        else
+          send_resp(
+            conn,
+            :unauthorized,
+            Jason.encode!(%{status: 401, message: "Oops! You must be logged in to do that."})
+          )
+          |> halt()
+        end
 
-      if user != nil do
-        conn
-      else
+      _ ->
         send_resp(
           conn,
           :unauthorized,
-          Jason.encode!(%{status: 401, message: "Oops! You must be logged in to do that."})
+          Jason.encode!(%{status: 401, message: "Oops! No Authorization header was sent."})
         )
         |> halt()
-      end
-    else
-      send_resp(
-        conn,
-        :unauthorized,
-        Jason.encode!(%{status: 401, message: "Oops! No Authorization header was sent."})
-      )
-      |> halt()
     end
   end
 end

--- a/lib/feed_me_web/controllers/plugs/verify_header.ex
+++ b/lib/feed_me_web/controllers/plugs/verify_header.ex
@@ -18,11 +18,19 @@ defmodule FeedMeWeb.Plugs.VerifyHeader do
       if user != nil do
         conn
       else
-        send_resp(conn, :unauthorized, "Oops! You must be logged in to do that.")
+        send_resp(
+          conn,
+          :unauthorized,
+          Jason.encode!(%{status: 401, message: "Oops! You must be logged in to do that."})
+        )
         |> halt()
       end
     else
-      send_resp(conn, :unauthorized, "Oops! You must be logged in to do that.")
+      send_resp(
+        conn,
+        :unauthorized,
+        Jason.encode!(%{status: 401, message: "Oops! No Authorization header was sent."})
+      )
       |> halt()
     end
   end

--- a/lib/feed_me_web/router.ex
+++ b/lib/feed_me_web/router.ex
@@ -31,6 +31,9 @@ defmodule FeedMeWeb.Router do
     get "/subscription", SubscriptionController, :index
     post "/subscription", SubscriptionController, :create
     options "/subscription", SubscriptionController, :nothing
+
+    get "/feed", FeedController, :index
+    options "/feed", FeedController, :nothing
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
### Description

These changes:
- update the `verify_header` response structure to send a message and a status code
- gracefully handle the situation where no auth token was provided
- add a GET all endpoint for feeds
