### PR TITLE
Subscription updates

### DIFF
--- a/lib/feed_me_web/controllers/plugs/verify_header.ex
+++ b/lib/feed_me_web/controllers/plugs/verify_header.ex
@@ -15,7 +15,7 @@ defmodule FeedMeWeb.Plugs.VerifyHeader do
         user = FeedMe.Account.get_user_by_token(token)
 
         if user != nil do
-          conn
+          assign(conn, :user, user)
         else
           send_resp(
             conn,

--- a/lib/feed_me_web/controllers/subscription_controller.ex
+++ b/lib/feed_me_web/controllers/subscription_controller.ex
@@ -28,8 +28,12 @@ defmodule FeedMeWeb.SubscriptionController do
 
   defp create_subscription(conn, feed) do
     case AccountContent.create_subscription(conn.assigns.user, feed) do
-      {:ok, subscription} ->
-        Conn.send_resp(conn, :ok, Jason.encode!(subscription))
+      {:ok, _subscription} ->
+        Conn.send_resp(
+          conn,
+          :ok,
+          Jason.encode!(%{status: 200, message: "Successfully subscribed!"})
+        )
 
       {:error, subscription_changeset} ->
         constraint_type = get_subscription_constraint_type(subscription_changeset.errors)

--- a/lib/feed_me_web/router.ex
+++ b/lib/feed_me_web/router.ex
@@ -5,7 +5,8 @@ defmodule FeedMeWeb.Router do
     plug :accepts, ["html"]
     plug :fetch_session
     plug :fetch_flash
-    plug :protect_from_forgery
+    # TODO: don't do this
+    # plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug CORSPlug, origin: "*"
   end


### PR DESCRIPTION
### Description

These changes:
- assign the user object to `conn` when the auth header is checked
- send a `200` status to the frontend when the sub already exists rather than an error
- update the successful subscription response format to include a `status` and a `message` rather than the subscription itself