### PR TITLE
Support feed item statuses

### DIFF
--- a/lib/feed_me/account_content.ex
+++ b/lib/feed_me/account_content.ex
@@ -8,17 +8,8 @@ defmodule FeedMe.AccountContent do
 
   alias FeedMe.AccountContent.Subscription
 
-  @doc """
-  Returns the list of subscriptions.
-
-  ## Examples
-
-      iex> list_subscriptions()
-      [%Subscription{}, ...]
-
-  """
-  def list_subscriptions do
-    Repo.all(Subscription)
+  def list_subscriptions(user_id) do
+    Subscription |> where(user_id: ^user_id) |> Repo.all()
   end
 
   @doc """

--- a/lib/feed_me/account_content.ex
+++ b/lib/feed_me/account_content.ex
@@ -39,6 +39,7 @@ defmodule FeedMe.AccountContent do
 
   @doc """
   Creates a subscription.
+  TODO: update docs
 
   ## Examples
 
@@ -120,21 +121,7 @@ defmodule FeedMe.AccountContent do
     Repo.all(FeedItemStatus)
   end
 
-  @doc """
-  Gets a single feed_item_status.
-
-  Raises `Ecto.NoResultsError` if the Feed item status does not exist.
-
-  ## Examples
-
-      iex> get_feed_item_status!(123)
-      %FeedItemStatus{}
-
-      iex> get_feed_item_status!(456)
-      ** (Ecto.NoResultsError)
-
-  """
-  def get_feed_item_status!(id), do: Repo.get!(FeedItemStatus, id)
+  def get_feed_item_status(id), do: Repo.get_by(FeedItemStatus, feed_item_id: id)
 
   @doc """
   Creates a feed_item_status.
@@ -148,9 +135,12 @@ defmodule FeedMe.AccountContent do
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_feed_item_status(attrs \\ %{}) do
-    %FeedItemStatus{}
-    |> FeedItemStatus.changeset(attrs)
+  def create_feed_item_status(feed_item, user, isRead) do
+    feed_item
+    |> Ecto.build_assoc(:feed_item_statuses)
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.put_assoc(:user, user)
+    |> FeedItemStatus.changeset(%{is_read: isRead})
     |> Repo.insert()
   end
 

--- a/lib/feed_me/content.ex
+++ b/lib/feed_me/content.ex
@@ -4,6 +4,8 @@ defmodule FeedMe.Content do
   """
 
   import Ecto.Query, warn: false
+  alias FeedMe.AccountContent
+  alias FeedMe.AccountContent.FeedItemStatus
   alias FeedMe.Content.Feed
   alias FeedMe.Content.FeedItem
   alias FeedMe.Repo
@@ -18,12 +20,23 @@ defmodule FeedMe.Content do
       [%Feed{}, ...]
 
   """
-  def list_feeds do
-    # TODO: only get feeds for current user
-    Repo.all(Feed)
+  def list_feeds(user_id) do
+    feed_ids =
+      AccountContent.list_subscriptions(user_id)
+      |> Enum.map(fn %{feed_id: feed_id} -> feed_id end)
+
+    query =
+      from(
+        f in Feed,
+        # TODO: preload feed items here when cron job is set up
+        where: f.id in ^feed_ids,
+        select: f
+      )
+
+    Repo.all(query)
     |> Enum.map(fn feed ->
       insert_all_feed_items(feed)
-      items = list_feed_items(feed.id)
+      items = list_feed_items(feed.id, user_id)
       Map.put(feed, :items, items)
     end)
   end
@@ -112,10 +125,11 @@ defmodule FeedMe.Content do
 
   alias FeedMe.Content.FeedItem
 
-  def list_feed_items(feed_id) do
+  def list_feed_items(feed_id, user_id) do
     FeedItem
     |> where(feed_id: ^feed_id)
     |> Repo.all()
+    |> Repo.preload(feed_item_statuses: from(s in FeedItemStatus, where: s.user_id == ^user_id))
     |> Enum.map(fn item -> convert_db_item_to_json_item(item) end)
   end
 
@@ -133,7 +147,11 @@ defmodule FeedMe.Content do
       ** (Ecto.NoResultsError)
 
   """
-  def get_feed_item!(id), do: Repo.get!(FeedItem, id) |> convert_db_item_to_json_item
+  def get_feed_item!(id, user_id) do
+    Repo.get!(FeedItem, id)
+    |> Repo.preload(feed_item_statuses: from(s in FeedItemStatus, where: s.user_id == ^user_id))
+    |> convert_db_item_to_json_item
+  end
 
   @doc """
   Creates a feed_item.
@@ -248,7 +266,19 @@ defmodule FeedMe.Content do
   end
 
   defp convert_db_item_to_json_item(item) do
-    Map.put(item, :description, :erlang.binary_to_term(item.description))
+    is_read =
+      case Enum.at(item.feed_item_statuses, 0) do
+        nil ->
+          nil
+
+        status ->
+          status.is_read
+      end
+
+    item
+    |> Map.drop([:feed_item_statuses])
+    |> Map.put(:isRead, is_read)
+    |> Map.put(:description, :erlang.binary_to_term(item.description))
   end
 
   defp convert_rss_items_to_db_items(items, feed_id) do

--- a/lib/feed_me/content.ex
+++ b/lib/feed_me/content.ex
@@ -278,6 +278,8 @@ defmodule FeedMe.Content do
     item
     |> Map.drop([:feed_item_statuses])
     |> Map.put(:isRead, is_read)
+    |> Map.put(:pubDate, item.pub_date)
+    |> Map.drop([:pub_date])
     |> Map.put(:description, :erlang.binary_to_term(item.description))
   end
 

--- a/lib/feed_me/content.ex
+++ b/lib/feed_me/content.ex
@@ -284,12 +284,17 @@ defmodule FeedMe.Content do
   end
 
   defp convert_rss_items_to_db_items(items, feed_id) do
-    Enum.map(items, fn %{"title" => title, "description" => description, "link" => url} ->
-      # TODO: convert `item.pubDate` into Date format
+    Enum.map(items, fn %{
+                         "title" => title,
+                         "description" => description,
+                         "link" => url,
+                         "pubDate" => pub_date
+                       } ->
       %{
         title: title,
         description: :erlang.term_to_binary(description, [:compressed]),
         url: url,
+        pub_date: pub_date,
         feed_id: feed_id
       }
     end)

--- a/lib/feed_me/content/feed_item.ex
+++ b/lib/feed_me/content/feed_item.ex
@@ -6,7 +6,7 @@ defmodule FeedMe.Content.FeedItem do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @derive {Jason.Encoder, only: [:id, :title, :description, :url, :pub_date, :isRead]}
+  @derive {Jason.Encoder, only: [:id, :title, :description, :url, :pubDate, :isRead]}
 
   schema "feed_items" do
     field :description, :string

--- a/lib/feed_me/content/feed_item.ex
+++ b/lib/feed_me/content/feed_item.ex
@@ -10,7 +10,7 @@ defmodule FeedMe.Content.FeedItem do
 
   schema "feed_items" do
     field :description, :string
-    field :pub_date, :date
+    field :pub_date, :string
     field :title, :string
     field :url, :string
     belongs_to :feed, FeedMe.Content.Feed

--- a/lib/feed_me/content/feed_item.ex
+++ b/lib/feed_me/content/feed_item.ex
@@ -6,7 +6,7 @@ defmodule FeedMe.Content.FeedItem do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @derive {Jason.Encoder, only: [:id, :title, :description, :url, :pub_date]}
+  @derive {Jason.Encoder, only: [:id, :title, :description, :url, :pub_date, :isRead]}
 
   schema "feed_items" do
     field :description, :string

--- a/lib/feed_me_web/controllers/feed_controller.ex
+++ b/lib/feed_me_web/controllers/feed_controller.ex
@@ -1,6 +1,7 @@
 defmodule FeedMeWeb.FeedController do
   use FeedMeWeb, :controller
 
+  alias FeedMe.AccountContent
   alias FeedMe.Content
   alias Plug.Conn
 
@@ -15,5 +16,48 @@ defmodule FeedMeWeb.FeedController do
   def get_item(conn, %{"id" => id}) do
     item = Content.get_feed_item!(id)
     Conn.send_resp(conn, :ok, Jason.encode!(item))
+  end
+
+  def update_item_status(conn, %{"id" => feed_item_id, "isRead" => is_read}) do
+    case AccountContent.get_feed_item_status(feed_item_id) do
+      nil ->
+        IO.puts("No feed item status found for ID #{feed_item_id}")
+        create_feed_item_status(conn, feed_item_id, is_read)
+
+      status = %AccountContent.FeedItemStatus{} ->
+        IO.puts("Feed item status found for ID #{feed_item_id}")
+        update_feed_item_status(conn, feed_item_id, status, is_read)
+
+      _error ->
+        IO.puts("Error getting feed item status for ID #{feed_item_id}")
+        Conn.send_resp(conn, :internal_server_error, "Error updating feed item status")
+    end
+  end
+
+  defp update_feed_item_status(conn, feed_item_id, status, is_read) do
+    IO.puts("Updating feed item status...")
+
+    case AccountContent.update_feed_item_status(status, %{is_read: is_read}) do
+      {:ok, _status} ->
+        Conn.send_resp(conn, :ok, Jason.encode!(%{status: 200, message: "Success"}))
+
+      {:error, _changeset} ->
+        IO.puts("Error updating feed item status for ID #{feed_item_id}")
+        Conn.send_resp(conn, :internal_server_error, "Error updating feed item status")
+    end
+  end
+
+  defp create_feed_item_status(conn, feed_item_id, is_read) do
+    IO.puts("Creating new feed item status...")
+    item = Content.get_feed_item!(feed_item_id)
+
+    case AccountContent.create_feed_item_status(item, conn.assigns.user, is_read) do
+      {:ok, _status} ->
+        Conn.send_resp(conn, :ok, Jason.encode!(%{status: 200, message: "Success"}))
+
+      {:error, _changeset} ->
+        IO.puts("Error creating feed item status for ID #{feed_item_id}")
+        Conn.send_resp(conn, :internal_server_error, "Error updating feed item status")
+    end
   end
 end

--- a/lib/feed_me_web/controllers/subscription_controller.ex
+++ b/lib/feed_me_web/controllers/subscription_controller.ex
@@ -9,7 +9,7 @@ defmodule FeedMeWeb.SubscriptionController do
   plug FeedMeWeb.Plugs.VerifyHeader, realm: "Bearer"
 
   def index(conn, _params) do
-    subscriptions = AccountContent.list_subscriptions()
+    subscriptions = AccountContent.list_subscriptions(conn.assigns.user.id)
     Conn.send_resp(conn, :ok, Jason.encode!(subscriptions))
   end
 

--- a/lib/feed_me_web/router.ex
+++ b/lib/feed_me_web/router.ex
@@ -34,8 +34,12 @@ defmodule FeedMeWeb.Router do
     options "/subscription", SubscriptionController, :nothing
 
     get "/feed", FeedController, :index
-    get "/item/:id", FeedController, :get_item
     options "/feed", FeedController, :nothing
+
+    post "/item", FeedController, :update_item_status
+    options "/item", FeedController, :nothing
+
+    get "/item/:id", FeedController, :get_item
     options "/item/:id", FeedController, :nothing
   end
 

--- a/priv/repo/migrations/20201113153254_change_pub_date_type.exs
+++ b/priv/repo/migrations/20201113153254_change_pub_date_type.exs
@@ -1,0 +1,9 @@
+defmodule FeedMe.Repo.Migrations.ChangePubDateType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:feed_items) do
+      modify :pub_date, :string
+    end
+  end
+end

--- a/test/feed_me/account_content_test.exs
+++ b/test/feed_me/account_content_test.exs
@@ -1,6 +1,6 @@
 defmodule FeedMe.AccountContentTest do
   use FeedMe.DataCase
-  use FeedMe.Fixtures, [:user, :feed]
+  use FeedMe.Fixtures, [:user, :feed, :feed_item]
 
   alias FeedMe.AccountContent
 
@@ -79,38 +79,49 @@ defmodule FeedMe.AccountContentTest do
   describe "feed_item_statuses" do
     alias FeedMe.AccountContent.FeedItemStatus
 
-    @valid_attrs %{is_read: true}
     @update_attrs %{is_read: false}
     @invalid_attrs %{is_read: nil}
 
-    def feed_item_status_fixture(attrs \\ %{}) do
-      {:ok, feed_item_status} =
-        attrs
-        |> Enum.into(@valid_attrs)
-        |> AccountContent.create_feed_item_status()
+    def feed_item_status_fixture do
+      feed_item = feed_item_fixture()
+      user = user_fixture()
+      is_read = true
+
+      {:ok, feed_item_status} = AccountContent.create_feed_item_status(feed_item, user, is_read)
 
       feed_item_status
     end
 
     test "list_feed_item_statuses/0 returns all feed_item_statuses" do
       feed_item_status = feed_item_status_fixture()
-      assert AccountContent.list_feed_item_statuses() == [feed_item_status]
+      assert AccountContent.list_feed_item_statuses() |> Repo.preload(:user) == [feed_item_status]
     end
 
-    test "get_feed_item_status!/1 returns the feed_item_status with given id" do
+    test "get_feed_item_status/1 returns the feed_item_status with given id" do
       feed_item_status = feed_item_status_fixture()
-      assert AccountContent.get_feed_item_status!(feed_item_status.id) == feed_item_status
+
+      assert AccountContent.get_feed_item_status(feed_item_status.feed_item_id)
+             |> Repo.preload(:user) ==
+               feed_item_status
     end
 
-    test "create_feed_item_status/1 with valid data creates a feed_item_status" do
+    test "create_feed_item_status/3 with valid data creates a feed_item_status" do
+      feed_item = feed_item_fixture()
+      user = user_fixture()
+      is_read = true
+
       assert {:ok, %FeedItemStatus{} = feed_item_status} =
-               AccountContent.create_feed_item_status(@valid_attrs)
+               AccountContent.create_feed_item_status(feed_item, user, is_read)
 
       assert feed_item_status.is_read == true
     end
 
     test "create_feed_item_status/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = AccountContent.create_feed_item_status(@invalid_attrs)
+      feed_item = feed_item_fixture()
+      user = user_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               AccountContent.create_feed_item_status(feed_item, user, @invalid_attrs)
     end
 
     test "update_feed_item_status/2 with valid data updates the feed_item_status" do
@@ -128,16 +139,16 @@ defmodule FeedMe.AccountContentTest do
       assert {:error, %Ecto.Changeset{}} =
                AccountContent.update_feed_item_status(feed_item_status, @invalid_attrs)
 
-      assert feed_item_status == AccountContent.get_feed_item_status!(feed_item_status.id)
+      assert feed_item_status ==
+               AccountContent.get_feed_item_status(feed_item_status.feed_item_id)
+               |> Repo.preload(:user)
     end
 
     test "delete_feed_item_status/1 deletes the feed_item_status" do
       feed_item_status = feed_item_status_fixture()
       assert {:ok, %FeedItemStatus{}} = AccountContent.delete_feed_item_status(feed_item_status)
 
-      assert_raise Ecto.NoResultsError, fn ->
-        AccountContent.get_feed_item_status!(feed_item_status.id)
-      end
+      assert AccountContent.get_feed_item_status(feed_item_status.feed_item_id) == nil
     end
 
     test "change_feed_item_status/1 returns a feed_item_status changeset" do

--- a/test/feed_me/account_content_test.exs
+++ b/test/feed_me/account_content_test.exs
@@ -11,8 +11,7 @@ defmodule FeedMe.AccountContentTest do
     @update_attrs %{is_subscribed: false}
     @invalid_attrs %{is_subscribed: nil}
 
-    def subscription_fixture do
-      user = user_fixture()
+    def subscription_fixture(user \\ user_fixture()) do
       feed = feed_fixture()
 
       {:ok, subscription} = AccountContent.create_subscription(user, feed)
@@ -20,9 +19,11 @@ defmodule FeedMe.AccountContentTest do
       subscription
     end
 
-    test "list_subscriptions/0 returns all subscriptions" do
-      subscription = subscription_fixture()
-      assert AccountContent.list_subscriptions() |> Repo.preload(:user) == [subscription]
+    test "list_subscriptions/1 returns all subscriptions" do
+      user = user_fixture()
+      subscription = subscription_fixture(user)
+
+      assert AccountContent.list_subscriptions(user.id) |> Repo.preload(:user) == [subscription]
     end
 
     test "get_subscription!/1 returns the subscription with given id" do

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -48,6 +48,28 @@ defmodule FeedMe.Fixtures do
     end
   end
 
+  def feed_item do
+    alias FeedMe.Content
+
+    quote do
+      @valid_attrs %{
+        title: "Mock Feed Item",
+        description: "Mock feed item description",
+        url: "https://mockfeeditem.com",
+        pub_date: "Wed, 28 Oct 2020 00:00:00 +0000"
+      }
+
+      def feed_item_fixture(attrs \\ %{}) do
+        {:ok, user} =
+          attrs
+          |> Enum.into(@valid_attrs)
+          |> Content.create_feed_item()
+
+        user
+      end
+    end
+  end
+
   @doc """
   Apply the `fixtures`.
   """


### PR DESCRIPTION
### Description

These changes:
- add a new endpoint to update feed item statuses
- include the item statuses in the feed GET payload
- convert `pub_date` field to a string