### PR TITLE
Add support for Heroku Scheduler

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,12 +31,6 @@ config :ueberauth, Ueberauth,
     github: {Ueberauth.Strategy.Github, [default_scope: "user:email", send_redirect_uri: false]}
   ]
 
-config :feed_me, FeedMe.Scheduler,
-  jobs: [
-    # At midnight every night
-    {"@daily", {FeedMe.AccountContent.FeedItemStorage, :store, []}}
-  ]
-
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -67,6 +67,12 @@ config :phoenix, :stacktrace_depth, 20
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime
 
+config :feed_me, FeedMe.Scheduler,
+  jobs: [
+    # At midnight every night
+    {"@daily", {FeedMe.AccountContent.FeedItemStorage, :store, []}}
+  ]
+
 defmodule DotEnv do
   def get_env(key) do
     case File.read("#{File.cwd!()}/.env") do

--- a/lib/feed_me_web/controllers/auth_controller.ex
+++ b/lib/feed_me_web/controllers/auth_controller.ex
@@ -21,6 +21,16 @@ defmodule FeedMeWeb.AuthController do
     sign_in(conn, changeset)
   end
 
+  def callback(%{assigns: %{ueberauth_failure: %{errors: errors}}} = conn, _params) do
+    IO.puts("Error authenticating via Ueberauth...")
+
+    conn
+    |> send_resp(
+      :internal_server_error,
+      Jason.encode!(%{status: 500, message: "Error signing in."})
+    )
+  end
+
   @spec logout(Plug.Conn.t(), any) :: Plug.Conn.t()
   def logout(conn, _params) do
     conn

--- a/lib/mix/tasks/store_new_feed_items.ex
+++ b/lib/mix/tasks/store_new_feed_items.ex
@@ -1,0 +1,16 @@
+defmodule Mix.Tasks.StoreNewFeedItems do
+  @moduledoc """
+  This module defined a mix task to store new feed items from feeds with subscriptions.
+  """
+  use Mix.Task
+
+  alias FeedMe.AccountContent.FeedItemStorage
+
+  @shortdoc "Simply calls the FeedItemStorage.store/0 function."
+  def run(_) do
+    # This will start our application
+    Mix.Task.run("app.start")
+
+    FeedItemStorage.store()
+  end
+end


### PR DESCRIPTION
### Description

These changes:
- handle ueberauth failure in the `AuthController`
- add a mix task to store new feed items