### PR TITLE
Feed refactors and fixes

### DIFF
--- a/lib/feed_me_web/controllers/feed_controller.ex
+++ b/lib/feed_me_web/controllers/feed_controller.ex
@@ -12,13 +12,13 @@ defmodule FeedMeWeb.FeedController do
   def index(conn, _params) do
     user_id = conn.assigns.user.id
 
-    feeds =
+    feeds_json =
       AccountContent.list_subscriptions(user_id)
       |> Enum.map(fn %{feed_id: feed_id} -> feed_id end)
       |> Content.list_feeds(user_id)
       |> Enum.map(&Content.convert_db_feed_to_json_feed/1)
 
-    Conn.send_resp(conn, :ok, Jason.encode!(%{status: 200, feeds: feeds}))
+    Conn.send_resp(conn, :ok, Jason.encode!(%{status: 200, feeds: feeds_json}))
   end
 
   def get_item(conn, %{"id" => feed_item_id}) do

--- a/lib/feed_me_web/controllers/feed_controller.ex
+++ b/lib/feed_me_web/controllers/feed_controller.ex
@@ -40,25 +40,7 @@ defmodule FeedMeWeb.FeedController do
         IO.puts("No feed item status found for ID #{feed_item_id}")
 
         item = Content.get_feed_item!(feed_item_id, user_id)
-
-        case create_status(conn, item, is_read) do
-          nil ->
-            Conn.send_resp(
-              conn,
-              :internal_server_error,
-              Jason.encode!(%{
-                status: 500,
-                message: "Error updating feed item status"
-              })
-            )
-
-          status ->
-            Conn.send_resp(
-              conn,
-              :ok,
-              Jason.encode!(%{status: 200, isRead: status.is_read})
-            )
-        end
+        create_status(conn, item, is_read)
 
       [status = %AccountContent.FeedItemStatus{}] ->
         IO.puts("Feed item status found for ID #{feed_item_id}")
@@ -106,11 +88,23 @@ defmodule FeedMeWeb.FeedController do
 
     case AccountContent.create_feed_item_status(item, conn.assigns.user, is_read) do
       {:ok, status} ->
-        status
+        Conn.send_resp(
+          conn,
+          :ok,
+          Jason.encode!(%{status: 200, isRead: status.is_read})
+        )
 
       {:error, _changeset} ->
         IO.puts("Error creating feed item status for ID #{item.id}")
-        nil
+
+        Conn.send_resp(
+          conn,
+          :internal_server_error,
+          Jason.encode!(%{
+            status: 500,
+            message: "Error updating feed item status"
+          })
+        )
     end
   end
 end


### PR DESCRIPTION
### Description

These changes refactor the feed logic so that we create an item status if it's missing when we serialize the data. 

Also, we are no longer preloading all statuses for the user on each item when the feed loads. This was causing an issue where new feed items (stored by the cron job) wouldn't render in a user's feed because there was no status associated with it.