### PR TITLE
Support ability to unsubscribe

### DIFF
--- a/lib/feed_me/account_content.ex
+++ b/lib/feed_me/account_content.ex
@@ -31,7 +31,10 @@ defmodule FeedMe.AccountContent do
 
   """
   def list_subscriptions(user_id) do
-    Subscription |> where(user_id: ^user_id) |> Repo.all()
+    Subscription
+    |> where(user_id: ^user_id)
+    |> Repo.all()
+    |> Enum.filter(fn sub -> sub.is_subscribed end)
   end
 
   @doc """
@@ -49,6 +52,14 @@ defmodule FeedMe.AccountContent do
 
   """
   def get_subscription!(id), do: Repo.get!(Subscription, id)
+
+  def get_subscription(feed_id, user_id) do
+    Repo.all(
+      from s in Subscription,
+        where: s.feed_id == ^feed_id and s.user_id == ^user_id,
+        select: s
+    )
+  end
 
   @doc """
   Creates a feed subscription for a user.
@@ -116,6 +127,12 @@ defmodule FeedMe.AccountContent do
   """
   def change_subscription(%Subscription{} = subscription, attrs \\ %{}) do
     Subscription.changeset(subscription, attrs)
+  end
+
+  def convert_subscription_to_json(subscription) do
+    subscription
+    |> Map.put(:isSubscribed, subscription.is_subscribed)
+    |> Map.put(:feedName, subscription.feed.name)
   end
 
   alias FeedMe.AccountContent.FeedItemStatus

--- a/lib/feed_me/account_content/subscription.ex
+++ b/lib/feed_me/account_content/subscription.ex
@@ -5,7 +5,7 @@ defmodule FeedMe.AccountContent.Subscription do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @derive {Jason.Encoder, only: [:id, :is_subscribed]}
+  @derive {Jason.Encoder, only: [:id, :isSubscribed, :feedName]}
 
   schema "subscriptions" do
     field :is_subscribed, :boolean, default: false

--- a/lib/feed_me/content.ex
+++ b/lib/feed_me/content.ex
@@ -259,10 +259,16 @@ defmodule FeedMe.Content do
   end
 
   def convert_db_feed_to_json_feed(feed, user) do
-    items = Enum.map(feed.feed_items, fn item -> convert_db_item_to_json_item(item, user) end)
+    case feed.feed_items do
+      %Ecto.Association.NotLoaded{} ->
+        feed
 
-    Map.put(feed, :items, items)
-    |> Map.drop([:feed_items])
+      _ ->
+        items = Enum.map(feed.feed_items, fn item -> convert_db_item_to_json_item(item, user) end)
+
+        Map.put(feed, :items, items)
+        |> Map.drop([:feed_items])
+    end
   end
 
   def convert_db_item_to_json_item(item, user) do

--- a/lib/feed_me_web/controllers/subscription_controller.ex
+++ b/lib/feed_me_web/controllers/subscription_controller.ex
@@ -53,6 +53,7 @@ defmodule FeedMeWeb.SubscriptionController do
         update_subscription(conn, subscription, %{is_subscribed: true})
 
       [] ->
+        Content.insert_all_feed_items(feed)
         create_subscription(conn, feed)
     end
   end
@@ -80,7 +81,6 @@ defmodule FeedMeWeb.SubscriptionController do
 
     case AccountContent.create_subscription(user, feed) do
       {:ok, _subscription} ->
-        Content.insert_all_feed_items(feed)
         AccountContent.insert_feed_item_statuses(user, feed)
 
         Conn.send_resp(

--- a/lib/feed_me_web/controllers/subscription_controller.ex
+++ b/lib/feed_me_web/controllers/subscription_controller.ex
@@ -8,7 +8,7 @@ defmodule FeedMeWeb.SubscriptionController do
   # This plug will execute before every handler in this list
   plug FeedMeWeb.Plugs.VerifyHeader, realm: "Bearer"
 
-  def create(conn, %{"url" => url}) do
+  def subscribe(conn, %{"url" => url}) do
     feed = Content.get_feed_from_rss_url(url)
 
     case Content.create_feed(feed) do

--- a/lib/feed_me_web/controllers/subscription_controller.ex
+++ b/lib/feed_me_web/controllers/subscription_controller.ex
@@ -8,21 +8,70 @@ defmodule FeedMeWeb.SubscriptionController do
   # This plug will execute before every handler in this list
   plug FeedMeWeb.Plugs.VerifyHeader, realm: "Bearer"
 
+  def index(conn, _params) do
+    user = conn.assigns.user
+
+    subs =
+      AccountContent.list_subscriptions(user.id)
+      |> FeedMe.Repo.preload(:feed)
+      |> Enum.map(&AccountContent.convert_subscription_to_json/1)
+
+    Conn.send_resp(
+      conn,
+      :ok,
+      Jason.encode!(%{status: 200, subscriptions: subs})
+    )
+  end
+
   def subscribe(conn, %{"url" => url}) do
     feed = Content.get_feed_from_rss_url(url)
 
     case Content.create_feed(feed) do
       {:ok, feed} ->
-        create_subscription(conn, feed)
+        update_or_create_subscription(conn, feed)
 
       {:error, feed_changeset} ->
         if get_feed_constraint_type(feed_changeset.errors) == :unique do
           IO.puts("Feed already exists. Creating subscription...")
-          create_subscription(conn, Content.get_feed_by_url!(url))
+          update_or_create_subscription(conn, Content.get_feed_by_url!(url))
         else
           IO.puts("Error creating new feed from url: #{url}")
           Conn.send_resp(conn, :internal_server_error, "Error creating feed")
         end
+    end
+  end
+
+  def unsubscribe(conn, %{"subscriptionId" => subscription_id}) do
+    subscription = AccountContent.get_subscription!(subscription_id)
+    # TODO: remove feed items from feed?
+    update_subscription(conn, subscription, %{is_subscribed: false})
+  end
+
+  defp update_or_create_subscription(conn, feed) do
+    case AccountContent.get_subscription(feed.id, conn.assigns.user.id) do
+      [subscription = %AccountContent.Subscription{}] ->
+        update_subscription(conn, subscription, %{is_subscribed: true})
+
+      [] ->
+        create_subscription(conn, feed)
+    end
+  end
+
+  defp update_subscription(conn, subscription, attrs) do
+    case AccountContent.update_subscription(subscription, attrs) do
+      {:ok, _subscription} ->
+        Conn.send_resp(
+          conn,
+          :ok,
+          Jason.encode!(%{status: 200, message: "Successfully updated subscription!"})
+        )
+
+      {:error, _changeset} ->
+        Conn.send_resp(
+          conn,
+          :internal_server_error,
+          "Error updating subscription #{subscription.id}"
+        )
     end
   end
 

--- a/lib/feed_me_web/router.ex
+++ b/lib/feed_me_web/router.ex
@@ -28,7 +28,9 @@ defmodule FeedMeWeb.Router do
 
     get "/", PageController, :index
 
+    get "/subscription", SubscriptionController, :index
     post "/subscription", SubscriptionController, :subscribe
+    delete "/subscription", SubscriptionController, :unsubscribe
     options "/subscription", SubscriptionController, :nothing
 
     get "/feed", FeedController, :index

--- a/lib/feed_me_web/router.ex
+++ b/lib/feed_me_web/router.ex
@@ -28,7 +28,7 @@ defmodule FeedMeWeb.Router do
 
     get "/", PageController, :index
 
-    post "/subscription", SubscriptionController, :create
+    post "/subscription", SubscriptionController, :subscribe
     options "/subscription", SubscriptionController, :nothing
 
     get "/feed", FeedController, :index


### PR DESCRIPTION
### Description

These changes:
- support ability for users to unsubscribe.
  - two new endpoints were added for subscription GET and DELETE
  - [corresponding frontend PR](https://github.com/sean-beard/feed-me/pull/23)
- move logic to insert feed items so that it happens _before_ we subscribe a user. This way, we prevent successful subs when the RSS feed format isn't supported