### PR TITLE
Add media metadata support for feed items

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: MIX_ENV=prod POOL_SIZE=2 mix ecto.migrate
 web: mix phx.server

--- a/lib/feed_me/content.ex
+++ b/lib/feed_me/content.ex
@@ -252,11 +252,12 @@ defmodule FeedMe.Content do
     is_read = is_feed_item_read(item, user)
 
     item
-    |> Map.drop([:feed_item_statuses])
     |> Map.put(:isRead, is_read)
     |> Map.put(:pubDate, item.pub_date)
-    |> Map.drop([:pub_date])
+    |> Map.put(:mediaType, item.media_type)
+    |> Map.put(:mediaUrl, item.media_url)
     |> Map.put(:description, :erlang.binary_to_term(item.description))
+    |> Map.drop([:feed_item_statuses, :pub_date, :media_type, :media_url])
   end
 
   defp is_feed_item_read(item, user) do

--- a/lib/feed_me/content/feed_item.ex
+++ b/lib/feed_me/content/feed_item.ex
@@ -6,13 +6,16 @@ defmodule FeedMe.Content.FeedItem do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @derive {Jason.Encoder, only: [:id, :title, :description, :url, :pubDate, :isRead]}
+  @derive {Jason.Encoder,
+           only: [:id, :title, :description, :url, :pubDate, :isRead, :mediaType, :mediaUrl]}
 
   schema "feed_items" do
     field :description, :string
     field :pub_date, :string
     field :title, :string
     field :url, :string
+    field :media_type, :string
+    field :media_url, :string
     belongs_to :feed, FeedMe.Content.Feed
     has_many :feed_item_statuses, FeedMe.AccountContent.FeedItemStatus
   end
@@ -20,7 +23,7 @@ defmodule FeedMe.Content.FeedItem do
   @doc false
   def changeset(feed_item, attrs) do
     feed_item
-    |> cast(attrs, [:title, :description, :url, :pub_date])
+    |> cast(attrs, [:title, :description, :url, :pub_date, :media_type, :media_url])
     |> validate_required([:title, :description, :url])
     |> foreign_key_constraint(:feed_id)
     |> unique_constraint([:url, :feed_id], name: :feed_items_index)

--- a/lib/feed_me/rss_utils.ex
+++ b/lib/feed_me/rss_utils.ex
@@ -118,6 +118,26 @@ defmodule FeedMe.RssUtils do
         "title" => title,
         "description" => description,
         "link" => url,
+        "pubDate" => pub_date,
+        "enclosure" => %{
+          "-type" => media_type,
+          "-url" => media_url
+        }
+      } ->
+        %{
+          title: title,
+          description: :erlang.term_to_binary(description, [:compressed]),
+          url: url,
+          pub_date: pub_date,
+          feed_id: feed_id,
+          media_type: media_type,
+          media_url: media_url
+        }
+
+      %{
+        "title" => title,
+        "description" => description,
+        "link" => url,
         "pubDate" => pub_date
       } ->
         %{

--- a/priv/repo/migrations/20210210061149_add_feed_item_media_fields.exs
+++ b/priv/repo/migrations/20210210061149_add_feed_item_media_fields.exs
@@ -1,0 +1,10 @@
+defmodule FeedMe.Repo.Migrations.AddFeedItemMediaFields do
+  use Ecto.Migration
+
+  def change do
+    alter table(:feed_items) do
+      add :media_type, :string
+      add :media_url, :string
+    end
+  end
+end


### PR DESCRIPTION
### Description

These changes:
- Add media metadata support for feed items (e.g. audio file support)
- Add support for running `mix ecto.migrate` automatically when deployed to Heroku (fixes #36)