### PR TITLE
Support saving current item time

### DIFF
--- a/lib/feed_me/account_content.ex
+++ b/lib/feed_me/account_content.ex
@@ -170,14 +170,14 @@ defmodule FeedMe.AccountContent do
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_feed_item_status(feed_item, user, is_read) do
+  def create_feed_item_status(feed_item, user, attrs) do
     feed_item
     |> Ecto.build_assoc(:feed_item_statuses)
     |> Ecto.Changeset.change()
     |> Ecto.Changeset.put_assoc(:user, user)
-    |> FeedItemStatus.changeset(%{is_read: is_read})
+    |> FeedItemStatus.changeset(attrs)
     |> Repo.insert(
-      on_conflict: [set: [is_read: is_read]],
+      on_conflict: [set: [is_read: attrs.is_read]],
       conflict_target: [:user_id, :feed_item_id]
     )
   end

--- a/lib/feed_me/account_content.ex
+++ b/lib/feed_me/account_content.ex
@@ -171,13 +171,15 @@ defmodule FeedMe.AccountContent do
 
   """
   def create_feed_item_status(feed_item, user, attrs) do
+    current_time_sec = Map.get(attrs, :current_time_sec, nil)
+
     feed_item
     |> Ecto.build_assoc(:feed_item_statuses)
     |> Ecto.Changeset.change()
     |> Ecto.Changeset.put_assoc(:user, user)
     |> FeedItemStatus.changeset(attrs)
     |> Repo.insert(
-      on_conflict: [set: [is_read: attrs.is_read]],
+      on_conflict: [set: [is_read: attrs.is_read, current_time_sec: current_time_sec]],
       conflict_target: [:user_id, :feed_item_id]
     )
   end
@@ -233,7 +235,7 @@ defmodule FeedMe.AccountContent do
     feed_with_items = feed |> Repo.preload(:feed_items)
 
     Enum.each(feed_with_items.feed_items, fn item ->
-      create_feed_item_status(item, user, false)
+      create_feed_item_status(item, user, %{is_read: false})
     end)
   end
 end

--- a/lib/feed_me/account_content/feed_item_status.ex
+++ b/lib/feed_me/account_content/feed_item_status.ex
@@ -8,6 +8,7 @@ defmodule FeedMe.AccountContent.FeedItemStatus do
 
   schema "feed_item_statuses" do
     field :is_read, :boolean, default: false
+    field :current_time_sec, :float
     belongs_to :feed_item, FeedMe.Content.FeedItem
     belongs_to :user, FeedMe.Account.User
 
@@ -17,7 +18,7 @@ defmodule FeedMe.AccountContent.FeedItemStatus do
   @doc false
   def changeset(feed_item_status, attrs) do
     feed_item_status
-    |> cast(attrs, [:is_read])
+    |> cast(attrs, [:is_read, :current_time_sec])
     |> validate_required([:is_read])
   end
 end

--- a/lib/feed_me/content.ex
+++ b/lib/feed_me/content.ex
@@ -295,7 +295,7 @@ defmodule FeedMe.Content do
   defp is_feed_item_read(item, user) do
     case AccountContent.get_feed_item_status(item.id, user.id) do
       [] ->
-        AccountContent.create_feed_item_status(item, user, false)
+        AccountContent.create_feed_item_status(item, user, %{is_read: false})
         false
 
       [status = %AccountContent.FeedItemStatus{}] ->

--- a/lib/feed_me/content/feed_item.ex
+++ b/lib/feed_me/content/feed_item.ex
@@ -7,7 +7,17 @@ defmodule FeedMe.Content.FeedItem do
   import Ecto.Changeset
 
   @derive {Jason.Encoder,
-           only: [:id, :title, :description, :url, :pubDate, :isRead, :mediaType, :mediaUrl]}
+           only: [
+             :id,
+             :title,
+             :description,
+             :url,
+             :pubDate,
+             :isRead,
+             :currentTime,
+             :mediaType,
+             :mediaUrl
+           ]}
 
   schema "feed_items" do
     field :description, :string

--- a/lib/feed_me_web/controllers/feed_controller.ex
+++ b/lib/feed_me_web/controllers/feed_controller.ex
@@ -27,9 +27,9 @@ defmodule FeedMeWeb.FeedController do
     user_id = conn.assigns.user.id
 
     items
-    |> Enum.each(fn %{"id" => item_id, "isRead" => is_read} ->
-      # TODO: add audio current time in sec here
-      create_or_update_feed_item_status(conn, item_id, user_id, is_read)
+    |> Enum.each(fn %{"id" => item_id, "isRead" => is_read, "currentTime" => current_time} ->
+      attrs = %{is_read: is_read, current_time_sec: current_time}
+      create_or_update_feed_item_status(conn, item_id, user_id, attrs)
     end)
 
     Conn.send_resp(
@@ -39,8 +39,8 @@ defmodule FeedMeWeb.FeedController do
     )
   end
 
-  defp create_or_update_feed_item_status(conn, feed_item_id, user_id, is_read) do
+  defp create_or_update_feed_item_status(conn, feed_item_id, user_id, attrs) do
     item = Content.get_feed_item!(feed_item_id, user_id)
-    AccountContent.create_feed_item_status(item, conn.assigns.user, %{is_read: is_read})
+    AccountContent.create_feed_item_status(item, conn.assigns.user, attrs)
   end
 end

--- a/lib/feed_me_web/controllers/feed_controller.ex
+++ b/lib/feed_me_web/controllers/feed_controller.ex
@@ -28,6 +28,7 @@ defmodule FeedMeWeb.FeedController do
 
     items
     |> Enum.each(fn %{"id" => item_id, "isRead" => is_read} ->
+      # TODO: add audio current time in sec here
       create_or_update_feed_item_status(conn, item_id, user_id, is_read)
     end)
 

--- a/lib/feed_me_web/controllers/feed_controller.ex
+++ b/lib/feed_me_web/controllers/feed_controller.ex
@@ -40,6 +40,6 @@ defmodule FeedMeWeb.FeedController do
 
   defp create_or_update_feed_item_status(conn, feed_item_id, user_id, is_read) do
     item = Content.get_feed_item!(feed_item_id, user_id)
-    AccountContent.create_feed_item_status(item, conn.assigns.user, is_read)
+    AccountContent.create_feed_item_status(item, conn.assigns.user, %{is_read: is_read})
   end
 end

--- a/priv/repo/migrations/20210302062738_add_item_status_field_current_time.exs
+++ b/priv/repo/migrations/20210302062738_add_item_status_field_current_time.exs
@@ -1,0 +1,9 @@
+defmodule FeedMe.Repo.Migrations.AddItemStatusFieldCurrentTime do
+  use Ecto.Migration
+
+  def change do
+    alter table(:feed_item_statuses) do
+      add :current_time_sec, :float
+    end
+  end
+end

--- a/test/feed_me/account_content_test.exs
+++ b/test/feed_me/account_content_test.exs
@@ -105,7 +105,7 @@ defmodule FeedMe.AccountContentTest do
       is_read = true
 
       assert {:ok, %FeedItemStatus{} = feed_item_status} =
-               AccountContent.create_feed_item_status(feed_item, user, is_read)
+               AccountContent.create_feed_item_status(feed_item, user, %{is_read: is_read})
 
       assert feed_item_status.is_read == true
     end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -78,7 +78,7 @@ defmodule FeedMe.Fixtures do
         feed_item = feed_item_fixture()
         is_read = true
 
-        {:ok, feed_item_status} = AccountContent.create_feed_item_status(feed_item, user, is_read)
+        {:ok, feed_item_status} = AccountContent.create_feed_item_status(feed_item, user, %{is_read: is_read})
 
         feed_item_status
       end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -78,7 +78,8 @@ defmodule FeedMe.Fixtures do
         feed_item = feed_item_fixture()
         is_read = true
 
-        {:ok, feed_item_status} = AccountContent.create_feed_item_status(feed_item, user, %{is_read: is_read})
+        {:ok, feed_item_status} =
+          AccountContent.create_feed_item_status(feed_item, user, %{is_read: is_read})
 
         feed_item_status
       end


### PR DESCRIPTION
### Description

These changes:
- update the `create_feed_item_status` contract 
- support saving current item time (e.g. audio player time when the user pauses)
