### PR TITLE
Enhance feed support

### DIFF
--- a/lib/feed_me/rss_utils.ex
+++ b/lib/feed_me/rss_utils.ex
@@ -137,6 +137,25 @@ defmodule FeedMe.RssUtils do
       %{
         "title" => title,
         "description" => description,
+        "pubDate" => pub_date,
+        "enclosure" => %{
+          "-type" => media_type,
+          "-url" => media_url
+        }
+      } ->
+        %{
+          title: title,
+          description: :erlang.term_to_binary(description, [:compressed]),
+          url: media_url,
+          pub_date: pub_date,
+          feed_id: feed_id,
+          media_type: media_type,
+          media_url: media_url
+        }
+
+      %{
+        "title" => title,
+        "description" => description,
         "link" => url,
         "pubDate" => pub_date
       } ->

--- a/priv/repo/migrations/20210320012850_change_feed_desc_type.exs
+++ b/priv/repo/migrations/20210320012850_change_feed_desc_type.exs
@@ -1,0 +1,9 @@
+defmodule FeedMe.Repo.Migrations.ChangeFeedDescType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:feeds) do
+      modify :description, :text
+    end
+  end
+end


### PR DESCRIPTION
### Description

These changes:
- change the feed description type to `text` to accommodate descriptions longer than 255 characters
- support media feed items without a link attribute (use the media link as the URL)