### PR TITLE
fix(FeedController): default to empty status

### DIFF
--- a/lib/feed_me_web/controllers/feed_controller.ex
+++ b/lib/feed_me_web/controllers/feed_controller.ex
@@ -33,7 +33,7 @@ defmodule FeedMeWeb.FeedController do
           nil ->
             # We don't want to set `current_time_sec` to `nil` when updating only `is_read`
             AccountContent.get_feed_item_status(item_id, user_id)
-            |> Enum.at(0)
+            |> Enum.at(0, %{})
             |> Map.get(:current_time_sec)
 
           time ->


### PR DESCRIPTION
fixes issue where `Map.get` is called on `nil` when there is no feed item status